### PR TITLE
feature: embed kontext version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 bin
+pkg/version/*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build
 bin
-pkg/version/*.txt
+pkg/version/data/*.txt

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TPARSE_VERSION ?= latest
 clean:
 	rm -rf build
 	rm -rf $(LOCALBIN)
+	rm -rf pkg/version/data/*.txt
 
 .PHONY: localbin
 localbin:
@@ -52,7 +53,7 @@ download: ## downloads the dependencies
 	go mod download -x
 
 .PHONY: build
-build: ## build kontext binary.
+build: generate ## build kontext binary.
 	go build -o build/kontext cmd/main.go
 
 .PHONY: run
@@ -77,3 +78,9 @@ test: tparse
 	set -o pipefail
 	go test ./... -cover -json | $(TPARSE)-$(TPARSE_VERSION) -all
 
+######################################################
+# generate
+######################################################
+.PHONY: generate
+generate: clean
+	go generate github.com/orbatschow/kontext/pkg/version

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -6,14 +6,16 @@ import (
 	"github.com/orbatschow/kontext/pkg/cmd/get"
 	"github.com/orbatschow/kontext/pkg/cmd/reload"
 	"github.com/orbatschow/kontext/pkg/cmd/set"
+	"github.com/orbatschow/kontext/pkg/version"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "kontext",
-	Short: "manage kubernetes config files, contexts, groups and sources",
-	Run:   set.NewSetContextCommand,
+	Use:     "kontext",
+	Version: version.Compute(),
+	Short:   "manage kubernetes config files, contexts, groups and sources",
+	Run:     set.NewSetContextCommand,
 }
 
 func Execute() {

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -17,7 +17,7 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		isVersionFlagSet := cmd.Flags().Lookup("version").Changed
 		if isVersionFlagSet {
-			println(version.Compute())
+			pterm.Printfln(version.Compute())
 			os.Exit(0)
 		}
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -12,10 +12,17 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "kontext",
-	Version: version.Compute(),
-	Short:   "manage kubernetes config files, contexts, groups and sources",
-	Run:     set.NewSetContextCommand,
+	Use:   "kontext",
+	Short: "manage kubernetes config files, contexts, groups and sources",
+	Run: func(cmd *cobra.Command, args []string) {
+		isVersionFlagSet := cmd.Flags().Lookup("version").Changed
+		if isVersionFlagSet {
+			println(version.Compute())
+			os.Exit(0)
+		}
+
+		set.NewSetContextCommand(cmd, args)
+	},
 }
 
 func Execute() {
@@ -23,6 +30,7 @@ func Execute() {
 	rootCmd.AddCommand(get.NewCommand())
 	rootCmd.AddCommand(set.NewCommand())
 	rootCmd.AddCommand(reload.NewCommand())
+	rootCmd.Flags().BoolP("version", "v", false, "version for kontext")
 
 	if err := rootCmd.Execute(); err != nil {
 		pterm.Printfln("%v", err)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,29 @@
+package version
+
+import (
+	_ "embed"
+	"strings"
+)
+
+const undefined = "undefined"
+
+//go:generate sh -c "git name-rev --tags --name-only $(git rev-parse HEAD) > data/tag.txt"
+//go:embed data/tag.txt
+var Tag string
+
+//go:generate sh -c "git rev-list --max-count=1 HEAD > data/commit.txt"
+//go:embed data/commit.txt
+var Commit string
+
+func Compute() string {
+	Tag = strings.ReplaceAll(Tag, "\n", "")
+	Commit = strings.ReplaceAll(Commit, "\n", "")
+
+	if Tag != undefined && len(Tag) > 0 {
+		return Tag
+	}
+	if Commit != undefined && len(Commit) > 0 {
+		return Commit
+	}
+	return "(devel)"
+}


### PR DESCRIPTION
- add a version flag, that will print out the current version
- version will be set to a git tag, if the current commit is tagged
- version will be set to a git commit, if there is not git tag, that points to the latest commit
- version will be set to (devel), when there is no git repository