### PR TITLE
fix: run make generate before creating releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 before:
   hooks:
     - go mod tidy
+    - make generate
 builds:
   - main: ./cmd/main.go
     env:


### PR DESCRIPTION
fix: run make generate before creating releases